### PR TITLE
初回判定offタイミング調整　臨時にWebHookURLをファイル読み込みできるように

### DIFF
--- a/WorldQuakeViewer/Main.cs
+++ b/WorldQuakeViewer/Main.cs
@@ -826,7 +826,8 @@ namespace WorldQuakeViewer//TODO:設定Formの作り直し
                     {
                         { "content", Text }
                     };
-                    Settings.Default.WebHook_URL = "";
+                    if (File.Exists("WebHookURL.txt"))//仮
+                        Settings.Default.WebHook_URL = File.ReadAllText("WebHookURL.txt");
                     await hc.PostAsync(Settings.Default.WebHook_URL, new FormUrlEncodedContent(strs));
                     hc.Dispose();
                     ExeLog($"[WebHook]WebHook送信成功");

--- a/WorldQuakeViewer/Main.cs
+++ b/WorldQuakeViewer/Main.cs
@@ -345,7 +345,6 @@ namespace WorldQuakeViewer//TODO:設定Formの作り直し
             }
             if (!ErrorText.Text.Contains("エラー"))
                 ErrorText.Text = "";
-            NoFirst = true;
             ExeLog("[EMSC]処理終了");
         }
 


### PR DESCRIPTION
NoFirstをtrueにするタイミングによっては初回判定による初回取得時処理防止ができない問題を確認したためUSGSの処理が終わった後のみとした。ただしこのタイミングはTweet等呼び出しを待たないためさらに調整する必要があるかもしれない。

WebHookURL.txtに入力してください。